### PR TITLE
fix: route GitHub Actions fixer prompts to gact

### DIFF
--- a/home/bin/executable_sase_chop_gh_actions_fix
+++ b/home/bin/executable_sase_chop_gh_actions_fix
@@ -320,7 +320,7 @@ def build_prompt(repo: str, run: dict[str, Any], failure_output: str) -> str:
     url = run.get("url") or "unknown"
 
     parts = [
-        f"#gh:{repo} %g:chop #pr({change_name}) %n:{agent_name}",
+        f"#gh:{repo} %g:gact #pr({change_name}) %n:{agent_name}",
         "",
         "The latest completed GitHub Actions run failed. Diagnose the root cause, fix the repository, "
         "and run the relevant checks. Do not commit unless explicitly requested.",


### PR DESCRIPTION
fix: route GitHub Actions fixer prompts to gact

Use the GitHub Actions agent group alias when generating CI fixer prompts so
the launcher matches the configured SASE group and regression test expectation.

---
**Model:** `codex/gpt-5.5`
**Agent:** `gha-fix-bbugyi200-dotfiles-25841607141-a1`