### PR TITLE
chore: regenerate sase_memory_read skills for tui_perf rename

### DIFF
--- a/home/dot_claude/skills/sase_memory_read/SKILL.md
+++ b/home/dot_claude/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```

--- a/home/dot_codex/skills/sase_memory_read/SKILL.md
+++ b/home/dot_codex/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```

--- a/home/dot_config/opencode/skills/sase_memory_read/SKILL.md
+++ b/home/dot_config/opencode/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```

--- a/home/dot_gemini/jetski/skills/sase_memory_read/SKILL.md
+++ b/home/dot_gemini/jetski/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```

--- a/home/dot_gemini/skills/sase_memory_read/SKILL.md
+++ b/home/dot_gemini/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```

--- a/home/dot_qwen/skills/sase_memory_read/SKILL.md
+++ b/home/dot_qwen/skills/sase_memory_read/SKILL.md
@@ -25,5 +25,5 @@ Examples:
 
 ```bash
 sase memory read long/generated_skills.md --reason "Need generated skill workflow before editing bundled skill sources"
-sase memory read long/tui_jk_baseline.md -r "Need baseline latency data before changing TUI navigation"
+sase memory read long/tui_perf.md -r "Need TUI performance gotchas before changing TUI navigation"
 ```


### PR DESCRIPTION
chore: regenerate sase_memory_read skills for tui_perf rename

Regenerate the per-provider sase_memory_read SKILL.md files so their
example command references memory/long/tui_perf.md instead of the
removed memory/long/tui_jk_baseline.md. This syncs the generated skills
with the updated skill source and fixes the `sase init --check` failure
in `just lint`.

AGENT=sase_fix_just-z
MACHINE=athena

---
**Model:** `claude/claude-fable-5`
**Agent:** `sase_fix_just-z`