### PR TITLE
fix: update bashunit installer URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,8 @@ jobs:
 
       - name: Install bashunit
         run: |
-          curl -s https://bashunit.typeddevs.com/install.sh | bash -s "$HOME/bin"
+          curl -fsSL https://bashunit.com/install.sh -o "$RUNNER_TEMP/bashunit-install.sh"
+          bash "$RUNNER_TEMP/bashunit-install.sh" "$HOME/bin"
           echo "$HOME/bin" >> $GITHUB_PATH
 
       - uses: extractions/setup-just@v2

--- a/home/.chezmoiscripts/run_onchange_install_bashunit.tmpl
+++ b/home/.chezmoiscripts/run_onchange_install_bashunit.tmpl
@@ -8,7 +8,17 @@ source ~/.local/share/chezmoi/lib/chezmoi_utils.sh
 function install_bashunit() {
   chez::log "INSTALLING LATEST VERSION OF BASHUNIT"
   pushd ~ &>/dev/null || exit
-  curl -s https://bashunit.typeddevs.com/install.sh | bash -s bin
+  local installer
+  installer="$(mktemp)"
+  curl -fsSL https://bashunit.com/install.sh -o "$installer" || {
+    rm -f "$installer"
+    return 1
+  }
+  bash "$installer" bin || {
+    rm -f "$installer"
+    return 1
+  }
+  rm -f "$installer"
 
   # Copy to the chezmoi data directory to fix neotest-bash
   # (see https://github.com/rcasia/neotest-bash/issues/14).

--- a/tests/nvim/smoke_tests.lua
+++ b/tests/nvim/smoke_tests.lua
@@ -148,6 +148,7 @@ describe("SMOKE TEST:", function()
 
 		holder_nvim = vim.fn.jobstart({
 			"nvim",
+			"--clean",
 			"--headless",
 			"--cmd",
 			"set directory=" .. temp_dir .. "//",


### PR DESCRIPTION
fix: update bashunit installer URL

Switch CI and the chezmoi installer script to the current bashunit install
endpoint, and download the installer before executing it so HTTP failures are
reported directly.

Also start the Neovim swap-file holder in smoke tests with --clean so unrelated
local plugin state cannot interfere with the test process.

AGENT=gha-fix-bbugyi200-dotfiles-28202585991-a1
MACHINE=athena

---
**Model:** `codex/gpt-5.5`
**Agent:** `gha-fix-bbugyi200-dotfiles-28202585991-a1`