### PR TITLE
ci: avoid apt dependency for LuaRocks setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -27,8 +27,13 @@ jobs:
       - name: Install prettier
         run: npm install -g prettier
 
-      - name: Install luarocks
-        run: sudo apt-get update && sudo apt-get install -y luarocks
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: "luajit-2.1"
+
+      - name: Set up LuaRocks
+        uses: leafo/gh-actions-luarocks@v6
 
       - name: Install lua-language-server
         run: |
@@ -36,13 +41,12 @@ jobs:
           mkdir -p "$HOME/lua-language-server"
           curl -sL "https://github.com/LuaLS/lua-language-server/releases/download/$LLS_VERSION/lua-language-server-$LLS_VERSION-linux-x64.tar.gz" \
             | tar xz -C "$HOME/lua-language-server"
-          echo "$HOME/lua-language-server/bin" >> $GITHUB_PATH
+          echo "$HOME/lua-language-server/bin" >> "$GITHUB_PATH"
 
       - name: Install Lua linters
         run: |
-          luarocks install --local llscheck
-          luarocks install --local luacheck
-          echo "$HOME/.luarocks/bin" >> $GITHUB_PATH
+          luarocks install llscheck
+          luarocks install luacheck
 
       - uses: extractions/setup-just@v2
 
@@ -79,12 +83,17 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
-      - name: Install luarocks
-        run: sudo apt-get update && sudo apt-get install -y luarocks
+      - name: Set up Lua
+        uses: leafo/gh-actions-lua@v13
+        with:
+          luaVersion: "luajit-2.1"
+
+      - name: Set up LuaRocks
+        uses: leafo/gh-actions-luarocks@v6
 
       - name: Set up Neovim
         uses: rhysd/action-setup-vim@v1
@@ -94,18 +103,15 @@ jobs:
 
       - name: Install Lua test tools
         run: |
-          luarocks install --local nlua
-          luarocks install --local busted
-          luarocks install --local luacov
-          echo "$HOME/.luarocks/bin" >> $GITHUB_PATH
-          echo "LUA_PATH=$(luarocks path --local --lr-path);;" >> $GITHUB_ENV
-          echo "LUA_CPATH=$(luarocks path --local --lr-cpath);;" >> $GITHUB_ENV
+          luarocks install nlua
+          luarocks install busted
+          luarocks install luacov
 
       - name: Install bashunit
         run: |
           curl -fsSL https://bashunit.com/install.sh -o "$RUNNER_TEMP/bashunit-install.sh"
           bash "$RUNNER_TEMP/bashunit-install.sh" "$HOME/bin"
-          echo "$HOME/bin" >> $GITHUB_PATH
+          echo "$HOME/bin" >> "$GITHUB_PATH"
 
       - uses: extractions/setup-just@v2
 


### PR DESCRIPTION
ci: avoid apt dependency for LuaRocks setup

Use Lua/LuaRocks setup actions in CI instead of installing LuaRocks through
apt, which can fail when hosted runner package sources are temporarily broken.
Also refresh setup-python and quote environment-file redirects flagged by the
workflow linter.

SASE_AGENT=gha-fix-bbugyi200-dotfiles-28899622211-a1
SASE_MACHINE=athena

---
**Model:** `codex/gpt-5.5`
**Agent:** `gha-fix-bbugyi200-dotfiles-28899622211-a1`