### PR TITLE
fix: ignore generated dependency markdown in lint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ repomix[-_]*.xml
 # Python virtual environment
 .venv
 
+# LuaRocks local install tree
+.luarocks/
+
 # Local SASE beads database
 .beads/
 sdd/beads/beads.db

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+.luarocks/
+.venv/


### PR DESCRIPTION
fix: ignore generated dependency markdown in lint

Prevent Markdown formatting checks from scanning local dependency install
trees created during CI setup. LuaRocks package documentation is third-party
content and should not determine this repository's lint result.

SASE_AGENT=gha-fix-bbugyi200-dotfiles-28900577152-a1
SASE_MACHINE=athena

---
**Model:** `codex/gpt-5.5`
**Agent:** `gha-fix-bbugyi200-dotfiles-28900577152-a1`