### PR TITLE
chore: update generated sase_run skills

### DIFF
--- a/home/dot_claude/skills/sase_run/SKILL.md
+++ b/home/dot_claude/skills/sase_run/SKILL.md
@@ -49,7 +49,8 @@ hard about the workspace and wait choices below; they determine where the agent 
 
 Standalone (non-family) prompts should normally start with a VCS workspace reference:
 
-- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or another plugin-provided workspace ref.
+- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or `#cd:<path>` (plain directory, no VCS
+  workspace management).
 - `<ref>` is usually a project name (`#gh:sase`). Use a ChangeSpec name (`#gh:my_change`) only when the agent must
   continue that existing PR branch, or `#gh:@agent` to target the ChangeSpec created by the named agent.
 - A prompt with no workspace reference defaults to `#git:home`, which is usually wrong for repo work.

--- a/home/dot_codex/skills/sase_run/SKILL.md
+++ b/home/dot_codex/skills/sase_run/SKILL.md
@@ -49,7 +49,8 @@ hard about the workspace and wait choices below; they determine where the agent 
 
 Standalone (non-family) prompts should normally start with a VCS workspace reference:
 
-- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or another plugin-provided workspace ref.
+- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or `#cd:<path>` (plain directory, no VCS
+  workspace management).
 - `<ref>` is usually a project name (`#gh:sase`). Use a ChangeSpec name (`#gh:my_change`) only when the agent must
   continue that existing PR branch, or `#gh:@agent` to target the ChangeSpec created by the named agent.
 - A prompt with no workspace reference defaults to `#git:home`, which is usually wrong for repo work.

--- a/home/dot_config/opencode/skills/sase_run/SKILL.md
+++ b/home/dot_config/opencode/skills/sase_run/SKILL.md
@@ -49,7 +49,8 @@ hard about the workspace and wait choices below; they determine where the agent 
 
 Standalone (non-family) prompts should normally start with a VCS workspace reference:
 
-- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or another plugin-provided workspace ref.
+- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or `#cd:<path>` (plain directory, no VCS
+  workspace management).
 - `<ref>` is usually a project name (`#gh:sase`). Use a ChangeSpec name (`#gh:my_change`) only when the agent must
   continue that existing PR branch, or `#gh:@agent` to target the ChangeSpec created by the named agent.
 - A prompt with no workspace reference defaults to `#git:home`, which is usually wrong for repo work.

--- a/home/dot_gemini/antigravity-cli/skills/sase_run/SKILL.md
+++ b/home/dot_gemini/antigravity-cli/skills/sase_run/SKILL.md
@@ -49,7 +49,8 @@ hard about the workspace and wait choices below; they determine where the agent 
 
 Standalone (non-family) prompts should normally start with a VCS workspace reference:
 
-- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or another plugin-provided workspace ref.
+- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or `#cd:<path>` (plain directory, no VCS
+  workspace management).
 - `<ref>` is usually a project name (`#gh:sase`). Use a ChangeSpec name (`#gh:my_change`) only when the agent must
   continue that existing PR branch, or `#gh:@agent` to target the ChangeSpec created by the named agent.
 - A prompt with no workspace reference defaults to `#git:home`, which is usually wrong for repo work.

--- a/home/dot_qwen/skills/sase_run/SKILL.md
+++ b/home/dot_qwen/skills/sase_run/SKILL.md
@@ -49,7 +49,8 @@ hard about the workspace and wait choices below; they determine where the agent 
 
 Standalone (non-family) prompts should normally start with a VCS workspace reference:
 
-- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or another plugin-provided workspace ref.
+- `#gh:<ref>` (GitHub), `#git:<ref>` (bare git), `#hg:<ref>` (Mercurial), or `#cd:<path>` (plain directory, no VCS
+  workspace management).
 - `<ref>` is usually a project name (`#gh:sase`). Use a ChangeSpec name (`#gh:my_change`) only when the agent must
   continue that existing PR branch, or `#gh:@agent` to target the ChangeSpec created by the named agent.
 - A prompt with no workspace reference defaults to `#git:home`, which is usually wrong for repo work.


### PR DESCRIPTION
chore: update generated sase_run skills

Regenerate provider skill outputs so validation sees the #cd workspace reference.

SASE_AGENT=sase_fix_just-0m
SASE_MACHINE=athena

---
**Model:** `codex/gpt-5.5`
**Agent:** `sase_fix_just-0m`